### PR TITLE
Increase `base` upper-bound

### DIFF
--- a/token-bucket.cabal
+++ b/token-bucket.cabal
@@ -35,7 +35,7 @@ flag use-cbits
 
 library
   default-language:    Haskell2010
-  build-depends:       base >=4.6 && <4.10
+  build-depends:       base >=4.6 && <4.17
   hs-source-dirs:      src
   if flag(use-cbits)
     cpp-options:       -DUSE_CBITS


### PR DESCRIPTION
We have been using `token-bucket` with GHC 9.2.5 for a while now without any problems, so I believe this `base` bound can be safely increased.